### PR TITLE
Upgrade vscode, evcxr_jupyter, and add lldb

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/opendatahub-contrib/workbench-images:vscode-datascience-c9s-py311_2023c_latest
+FROM quay.io/modh/codeserver:codeserver-ubi9-python-3.11-20250326
 
 USER root
 
@@ -7,9 +7,11 @@ ENV \
   CARGO_HOME=/usr/local
 
 RUN yum install -y \
-  cargo
+  cargo \
+  lldb \
+  rust-lldb
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-RUN cargo install evcxr_jupyter --version 0.14.0
+RUN cargo install evcxr_jupyter --version 0.19.0
 RUN evcxr_jupyter --install
 RUN install -d /opt/app-root/share/jupyter/kernels/rust
 RUN mv /opt/app-root/src/.local/share/jupyter/kernels/rust /opt/app-root/share/jupyter/kernels/rust
@@ -18,3 +20,4 @@ RUN pip install \
   bash_kernel \
   jupyterlab
 RUN python -m bash_kernel.install
+


### PR DESCRIPTION
We will use Red Hat's upstream OpenShift AI image for vscode. We will
also upgrade evcxr_jupyter to version 0.19.0. Also adding lldb and
rust-lldb debugger dependencies.

Closes nerc-project/operations/issues/1040
